### PR TITLE
138 - Tooltips and user instructions 

### DIFF
--- a/css/gloss.css
+++ b/css/gloss.css
@@ -1,6 +1,7 @@
 @import "https://unpkg.com/chota@latest";
 @import url('https://fonts.googleapis.com/css2?family=Eczar&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Volkhov&display=swap');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css');
 
 :root {
   --bg-color: hsl(0, 0%, 100%);
@@ -481,6 +482,10 @@ line.selected.just {
   margin-bottom: 1em;
 }
 
+.addWitnessDiv{
+  margin-bottom: 1em;
+}
+
 form#ngForm
 {
   margin: 0.7em;
@@ -501,19 +506,4 @@ input#loadInput {
 
 .content.container {
   margin-left: -.001em;
-}
-
-.input-with-icon {
-    position: relative;
-    display: flex;
-    align-items: center;
-}
-
-.input-with-icon input {
-    width: calc(100% - 30px); 
-}
-
-.icon-help {
-    position: absolute;
-    right: 5px; 
 }

--- a/css/gloss.css
+++ b/css/gloss.css
@@ -502,3 +502,18 @@ input#loadInput {
 .content.container {
   margin-left: -.001em;
 }
+
+.input-with-icon {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.input-with-icon input {
+    width: calc(100% - 30px); 
+}
+
+.icon-help {
+    position: absolute;
+    right: 5px; 
+}

--- a/gloss-transcription.html
+++ b/gloss-transcription.html
@@ -36,7 +36,7 @@
     <div id="needs" class="row bg-basic">
         <p class="howTo"> 
             It looks like you haven't provided a TPEN Manifest URI.  If you are not using the <code>?tpen-project=</code> URL parameter, you can supply a URI here.  
-            <input id="resourceURI" type="text" placeholder="TPEN Manifest URI"/>
+            <input id="resourceURI" type="text" placeholder="Enter TPEN Manifest URI or 4 digit TPEN code"/>
             <input id="loadInput" class="button primary" type="button" onclick="loadURI(event)" value="Load TPEN Manifest" />
         </p>
     </div>

--- a/gloss-transcription.html
+++ b/gloss-transcription.html
@@ -36,7 +36,7 @@
     <div id="needs" class="row bg-basic">
         <p class="howTo"> 
             It looks like you haven't provided a TPEN Manifest URI.  If you are not using the <code>?tpen-project=</code> URL parameter, you can supply a URI here.  
-            <input id="resourceURI" type="text" placeholder="Enter TPEN Manifest URI or 4 digit TPEN code"/>
+            <input id="resourceURI" type="text" placeholder="Enter T-PEN Manifest URI or 4 digit TPEN code"/>
             <input id="loadInput" class="button primary" type="button" onclick="loadURI(event)" value="Load TPEN Manifest" />
         </p>
     </div>

--- a/js/ng.js
+++ b/js/ng.js
@@ -6,7 +6,9 @@ window.onload = () => {
     const glossForm = document.getElementById("named-gloss")
     if(hash) {
         document.querySelector("gog-references-browser").setAttribute("gloss-uri", hash)
+        document.querySelectorAll(".addWitnessDiv").forEach(div => div.classList.remove("is-hidden"))
         document.querySelectorAll(".addWitnessBtn").forEach(btn => btn.classList.remove("is-hidden"))
+        
     }
     const labelElem = glossForm.querySelector('input[deer-key="title"]')
     const textElem = glossText

--- a/ng.html
+++ b/ng.html
@@ -5,6 +5,7 @@
     <title>Gallery of Glosses</title>
     <link rel="stylesheet" href="css/gloss.css">
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
     <script src="js/auth.js" type="module"></script>
     <script src="js/deer.js" type="module"></script>
     <script src="js/layout.js" type="module"></script>
@@ -21,15 +22,18 @@
         avoid creating a new one unless it does not already exist.
     </p>
     <gog-references-browser class="bg-light is-hidden"> </gog-references-browser>
-    <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss(true)">Add a T-PEN Transcription Witness for this Gloss</button>
-    <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss()">Add a Textual Witness for this Gloss</button>
+    <!-- Center & make a white background div with buttons inside, decide color later -->
+    <div style="display: flex; justify-content: center; background-color: white; padding: 10px; gap: 20px; flex-wrap: wrap;">
+        <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss(true)" style="margin: 5px; padding: 10px; border: none; border-radius: 4px;">Add a T-PEN Transcription Witness for this Gloss</button>
+        <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss()" style="margin: 5px; padding: 10px; border: none; border-radius: 4px;">Add a Textual Witness for this Gloss</button>
+    </div>
     <form id="named-gloss" deer-type="Gloss" deer-context="http://purl.org/dc/terms" hash-id>
         <input type="hidden" deer-key="targetCollection" value="GoG-Named-Glosses">
         <input is="auth-creator" type="hidden" deer-key="creator" />
         <div class="row">
-            <label class="col-3 col-2-md text-right">Gloss Text:</label>
+            <label class="col-3 col-2-md text-right">Gloss Text: <i class="fas fa-info-circle icon-help" title="Enter the content of the gloss here."></i></label>
             <textarea custom-text-key="text" id="glossText" placeholder="text content" rows="2" class="col-9 col-10-md"></textarea>
-
+            
             <label for="textLang" class="col-3 col-2-md text-right">Language:</label>
             <select custom-text-key="language" name="textLang" id="textLang" class="col-3 col-2-md">
                 <option value="la" selected>Latin</option>
@@ -43,26 +47,26 @@
             </label>
         </div>
         <div class="row">
-            <label class="col-3 col-2-md text-right">Description:</label>
+            <label class="col-3 col-2-md text-right">Description: <i title="Provide a brief description or summary of the gloss."></i></label>
             <input type="text" deer-key="description" placeholder="description" class="col-9 col-10-md">
-            <label class="col-3 col-2-md text-right">Canonical Reference Locator:</label>
+            <label class="col-3 col-2-md text-right">Canonical Reference Locator: <i class="fas fa-info-circle icon-help" title="Enter a reference to the location in the source text, like 'Matthew 5:1'."></i></label>
             <input type="text" deer-key="canonicalReference" placeholder='e.g., "Matthew 5:1"' class="col-9 col-4-md">
             <button class="col-6" type="button" role="button" onclick="parseSections()">parse sections</button>
-            <label class="col-3 col-2-md text-right">Document:</label>
+            <label class="col-3 col-2-md text-right">Document: <i class="fas fa-info-circle icon-help" title="Specify the document or source from which the gloss is taken"></i></label>
             <input type="text" deer-key="_document" placeholder='e.g., "Matthew"' class="col-9 col-4-md">
-            <label class="col-3 col-2-md text-right">Section:</label>
+            <label class="col-3 col-2-md text-right">Section: <i class="fas fa-info-circle icon-help" title="Indicate the specific chapter or section of the document."></i></label>
             <input type="text" deer-key="_section" placeholder="chapter" class="col-9 col-4-md">
-            <label class="col-3 col-2-md text-right">Subsection(s):</label>
+            <label class="col-3 col-2-md text-right">Subsection(s): <i class="fas fa-info-circle icon-help" title="Mention the particular verse or subsections referred to in the gloss."></i></label>
             <input type="text" deer-key="_subsection" placeholder="verse" class="col-9 col-4-md">
         </div>
         <div class="row">
-            <label class="col-3 col-2-md text-right">Target Text:</label>
-            <textarea deer-key="targetedText" rows="2" class="col-9 col-10-md" placeholder="target text"></textarea>
-            <label class="col-3 col-2-md text-right">Label for display:</label>
+            <label class="col-3 col-2-md text-right">Target Text: <i class="fas fa-info-circle icon-help" title="Input the text that this gloss is aimed at or elaborates upon."></i></label>
+            <textarea deer-key="targetedText" rows="2" class="col-9 col-10-md" placeholder="target text" ></textarea>
+            <label class="col-3 col-2-md text-right">Label for display: <i class="fas fa-info-circle icon-help" title="Enter the Incipit or identifying label here"></i></label>
             <input type="text" deer-key="title" placeholder="Short label" class="col-9 col-10-md">
         </div>
         <div class="row">
-            <label class="col-3 col-2-md text-right">Notes</label>
+            <label class="col-3 col-2-md text-right">Notes: <i class="fas fa-info-circle icon-help" title="Add any internal notes or comments here for reference."></i></label>
             <input type="text" deer-key="_notes" placeholder="internal notes" class="col-9 col-10-md">
         </div>
         <div class="row">
@@ -73,6 +77,7 @@
             <div class="col">
                 <p> Before submitting you can check for existing Glosses that may already contain the text provided above. </p>
                 <button type="button" id="checkForGlossesBtn"> Check for Existing Glosses </button>
+
                 <div id="glossResult"></div>
             </div>
         </div>

--- a/ng.html
+++ b/ng.html
@@ -51,7 +51,7 @@
             <label class="col-3 col-2-md text-right">Canonical Reference Locator: <i class="fas fa-info-circle icon-help" title="Enter a reference to the location in the source text, like 'Matthew 5:1'."></i></label>
             <input type="text" deer-key="canonicalReference" placeholder='e.g., "Matthew 5:1"' class="col-9 col-4-md">
             <button class="col-6" type="button" role="button" onclick="parseSections()">parse sections</button>
-            <label class="col-3 col-2-md text-right">Document: <i class="fas fa-info-circle icon-help" title="Specify the document or source from which the gloss is taken"></i></label>
+            <label class="col-3 col-2-md text-right">Document: <i class="fas fa-info-circle icon-help" title="Specify the document or source from which the gloss is taken."></i></label>
             <input type="text" deer-key="_document" placeholder='e.g., "Matthew"' class="col-9 col-4-md">
             <label class="col-3 col-2-md text-right">Section: <i class="fas fa-info-circle icon-help" title="Indicate the specific chapter or section of the document."></i></label>
             <input type="text" deer-key="_section" placeholder="chapter" class="col-9 col-4-md">
@@ -61,11 +61,11 @@
         <div class="row">
             <label class="col-3 col-2-md text-right">Target Text: <i class="fas fa-info-circle icon-help" title="Input the text that this gloss is aimed at or elaborates upon."></i></label>
             <textarea deer-key="targetedText" rows="2" class="col-9 col-10-md" placeholder="target text" ></textarea>
-            <label class="col-3 col-2-md text-right">Label for display: <i class="fas fa-info-circle icon-help" title="Enter the Incipit or identifying label here"></i></label>
+            <label class="col-3 col-2-md text-right">Label for display: <i class="fas fa-info-circle icon-help" title="Enter the incipit or identifying label."></i></label>
             <input type="text" deer-key="title" placeholder="Short label" class="col-9 col-10-md">
         </div>
         <div class="row">
-            <label class="col-3 col-2-md text-right">Notes: <i class="fas fa-info-circle icon-help" title="Add any internal notes or comments here for reference."></i></label>
+            <label class="col-3 col-2-md text-right">Notes: <i class="fas fa-info-circle icon-help" title="Enter internal notes or comments about this gloss."></i></label>
             <input type="text" deer-key="_notes" placeholder="internal notes" class="col-9 col-10-md">
         </div>
         <div class="row">

--- a/ng.html
+++ b/ng.html
@@ -5,7 +5,6 @@
     <title>Gallery of Glosses</title>
     <link rel="stylesheet" href="css/gloss.css">
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
     <script src="js/auth.js" type="module"></script>
     <script src="js/deer.js" type="module"></script>
     <script src="js/layout.js" type="module"></script>
@@ -23,7 +22,7 @@
     </p>
     <gog-references-browser class="bg-light is-hidden"> </gog-references-browser>
     <!-- Center & make a white background div with buttons inside, decide color later -->
-    <div style="display: flex; justify-content: center; background-color: white; padding: 10px; gap: 20px; flex-wrap: wrap;">
+    <div class="addWitnessDiv is-hidden" style="display: flex; justify-content: center; background-color: white; padding: 10px; gap: 20px; flex-wrap: wrap;">
         <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss(true)" style="margin: 5px; padding: 10px; border: none; border-radius: 4px;">Add a T-PEN Transcription Witness for this Gloss</button>
         <button class="addWitnessBtn button is-hidden" onclick="witnessForGloss()" style="margin: 5px; padding: 10px; border: none; border-radius: 4px;">Add a Textual Witness for this Gloss</button>
     </div>

--- a/properties.json
+++ b/properties.json
@@ -1,7 +1,7 @@
 {
-    "ngCollection" : "https://store.rerum.io/v1/id/610c54deffce846a83e70625",
-    "msCollection" : "https://store.rerum.io/v1/id/610ad6f1ffce846a83e70613",
-    "generator" : "http://store.rerum.io/v1/id/61043ad4ffce846a83e700dd",
-    "tiny" : "https://tinymatt.rerum.io/gloss",
-    "rerum" : "https://store.rerum.io/v1"
+    "ngCollection" : "https://devstore.rerum.io/v1/id/610c54deffce846a83e70625",
+    "msCollection" : "https://devstore.rerum.io/v1/id/610ad6f1ffce846a83e70613",
+    "generator" : "http://devstore.rerum.io/v1/id/5afeebf3e4b0b0d588705d90",
+    "tiny" : "https://tinydev.rerum.io/app",
+    "rerum" : "https://devstore.rerum.io/v1"
 }


### PR DESCRIPTION
PR for issue #138
1. Added help icon by labels to help users understand what they're filling out on ng.html
2. Added instruction for users to see that they can enter 4 digit TPEN code http://localhost:8080/gloss-transcription.html
3. Changed the background of the witness buttons for better visibility (Btn colors are undecided)

Before:
![image](https://github.com/CenterForDigitalHumanities/glossing-entries/assets/131922588/8691602b-ad51-49a5-9e0a-2fb29033da0a)
![image](https://github.com/CenterForDigitalHumanities/glossing-entries/assets/131922588/dc4ead6c-de54-4d88-8c83-d9184e5bcb75)

After:
![image](https://github.com/CenterForDigitalHumanities/glossing-entries/assets/131922588/64484ea5-248e-45eb-8193-d3980344f3db)
![image](https://github.com/CenterForDigitalHumanities/glossing-entries/assets/131922588/46693291-cb26-4b8c-834e-e7b2384b243a)
