### PR TITLE
Enhance UX by Conditionally Disabling Form Elements on Gloss Page

### DIFF
--- a/css/gloss.css
+++ b/css/gloss.css
@@ -534,3 +534,8 @@ input#loadInput {
 .nomargin{
   margin: 0;
 }
+
+textarea:disabled, select:disabled {
+  cursor: not-allowed;
+  opacity: .4;
+}

--- a/js/ng.js
+++ b/js/ng.js
@@ -18,6 +18,7 @@ window.onload = () => {
     
     const glossForm = document.getElementById("named-gloss")
     if(hash) {
+        setFieldDisabled(true)
         document.querySelector("gog-references-browser").setAttribute("gloss-uri", hash)
         document.querySelectorAll(".addWitnessDiv").forEach(div => div.classList.remove("is-hidden"))
         document.querySelectorAll(".addWitnessBtn").forEach(btn => btn.classList.remove("is-hidden"))
@@ -105,6 +106,7 @@ addEventListener('deer-form-rendered', event => {
             break
         default:
     }
+    setFieldDisabled(false)
 })
 
 /**
@@ -476,4 +478,12 @@ async function deleteGloss(id=glossHashID) {
         console.log(err)
     })
 
+}
+
+/**
+ * Enable/Disable all form fields
+ * @param {boolean} disabled - Set all form fields used to have this value for their `disabled` attribute
+ */
+function setFieldDisabled(disabled = true) {
+    document.querySelectorAll('input,textarea,select,button').forEach(e => e.disabled = disabled)
 }

--- a/ng.html
+++ b/ng.html
@@ -90,11 +90,35 @@
 </body>
 
 <script>
-    /**
-     * Make sure DEER forms do not submit when a user hits "Enter".
-     */ 
+    // Function to disable or enable all input fields
+    function toggleFormElements(disabled) {
+        document.querySelectorAll('input, textarea, select, button').forEach(element => {
+            element.disabled = disabled
+        });
+    }
+
+    // Disable all fields initially
+    toggleFormElements(true)
+
+    // Event listener for DEER forms
+    document.addEventListener('deer-form-rendered', function() {
+        // Enable all form elements once the form has been rendered with data
+        toggleFormElements(false)
+    });
+
+    // Check if we are creating a new gloss
+    document.addEventListener('DOMContentLoaded', function() {
+        // Assuming you have a way to determine if this is a new gloss creation
+        // E.g., by checking the URL, a hidden input field, etc.
+        // Here we simply check if the form is empty, as an example
+        if (!document.querySelector('#glossText').value) {
+            toggleFormElements(false)
+        }
+    });
+
+    // Prevent form submission with "Enter" key
     document.querySelectorAll("form[deer-type]").forEach(form => {
-        form.addEventListener("keydown", (e)=> {
+        form.addEventListener("keydown", (e) => {
             if (e.keyIdentifier == 'U+000A' || e.keyIdentifier == 'Enter' || e.keyCode == 13) {
                 if (e.target.nodeName == 'INPUT' && e.target.type == 'text') {
                     e.preventDefault()

--- a/ng.html
+++ b/ng.html
@@ -90,33 +90,9 @@
 </body>
 
 <script>
-    // Function to disable or enable all input fields
-    function toggleFormElements(disabled) {
-        document.querySelectorAll('input, textarea, select, button').forEach(element => {
-            element.disabled = disabled
-        });
-    }
-
-    // Disable all fields initially
-    toggleFormElements(true)
-
-    // Event listener for DEER forms
-    document.addEventListener('deer-form-rendered', function() {
-        // Enable all form elements once the form has been rendered with data
-        toggleFormElements(false)
-    });
-
-    // Check if we are creating a new gloss
-    document.addEventListener('DOMContentLoaded', function() {
-        // Assuming you have a way to determine if this is a new gloss creation
-        // E.g., by checking the URL, a hidden input field, etc.
-        // Here we simply check if the form is empty, as an example
-        if (!document.querySelector('#glossText').value) {
-            toggleFormElements(false)
-        }
-    });
-
-    // Prevent form submission with "Enter" key
+    /**
+     * Make sure DEER forms do not submit when a user hits "Enter".
+     */ 
     document.querySelectorAll("form[deer-type]").forEach(form => {
         form.addEventListener("keydown", (e)=> {
             if (e.keyIdentifier == 'U+000A' || e.keyIdentifier == 'Enter' || e.keyCode == 13) {

--- a/ng.html
+++ b/ng.html
@@ -118,7 +118,7 @@
 
     // Prevent form submission with "Enter" key
     document.querySelectorAll("form[deer-type]").forEach(form => {
-        form.addEventListener("keydown", (e) => {
+        form.addEventListener("keydown", (e)=> {
             if (e.keyIdentifier == 'U+000A' || e.keyIdentifier == 'Enter' || e.keyCode == 13) {
                 if (e.target.nodeName == 'INPUT' && e.target.type == 'text') {
                     e.preventDefault()


### PR DESCRIPTION
Made changes on ng.html.

Here is the issue description: 

When opening a gloss on ng.html, there tends to be some delay between the page loading and the data filling. Because of this, the user can input data into what appears to be an empty page only for it to be completely deleted when the data is loaded. To prevent this, the input elements on the page should be disabled until the data is fully loaded as signaled by the deer-form-rendered event but additional logic will likely have to be implemented to account for opening the page to create a new gloss as doing so never throws that event since there is nothing to load.

Here is what was changed thus far: 

Initial Disabling: When the page first loads, all input fields, text areas, selection menus, and buttons are disabled. This means you can't type, select, or click anything initially.

Enabling on Data Load: If the page is meant to display an existing gloss (i.e., the form is being populated with existing data), the fields are enabled only after the data has fully loaded. This is signaled by the deer-form-rendered event.

Handling New Gloss Creation: If the page is opened to create a new gloss (where no existing data needs to be loaded), the form fields are enabled right away since there’s no need to wait for data.

Preventing Form Submission with Enter Key: Added a small script to prevent the form from being submitted when the Enter key is pressed in a text input field, helping avoid accidental submissions.